### PR TITLE
Make this plugin load after DiscordMC

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: 1.1.1
 description: Uploads backups to Google Drive
 main: ratismal.drivebackup.DriveBackup
 author: Ratismal
+softdepend: [DiscordMC]
 commands:
   driveBackup:
     description: See all DriveBackup commands


### PR DESCRIPTION
This will fix the old version of jackson dependency to load the one DiscordMC uses. Bad way to do it, but easier way.